### PR TITLE
Resolve 131: Change `exit` to `main screen` in-Pause Menu 

### DIFF
--- a/Assets/Prefabs/Core/UI/Pause Menu.prefab
+++ b/Assets/Prefabs/Core/UI/Pause Menu.prefab
@@ -283,7 +283,7 @@ GameObject:
   - component: {fileID: 3852147110611589669}
   - component: {fileID: 2411890767930542837}
   m_Layer: 0
-  m_Name: Exit
+  m_Name: Main Menu
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -393,7 +393,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 2021277279248452878}
         m_TargetAssemblyTypeName: EVOGAMI.UI.PanelMenu.PauseMenu, Assembly-CSharp
-        m_MethodName: OnExitClicked
+        m_MethodName: OnMainMenuClicked
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -821,7 +821,7 @@ GameObject:
   - component: {fileID: 8925872379882712022}
   - component: {fileID: 8520417477244743809}
   m_Layer: 0
-  m_Name: Exit (TMP)
+  m_Name: Main Menu (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -874,7 +874,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'EXIT
+  m_text: 'Main Menu
 
 '
   m_isRightToLeft: 0

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -57,7 +57,7 @@ namespace EVOGAMI.Core
 
         #region Scene Management
 
-        private void LoadStartMenu()
+        public void LoadStartMenu()
         {
             // Load the start menu scene
             SceneManager.LoadScene(startMenuScene);

--- a/Assets/Scripts/UI/PanelMenu/PauseMenu.cs
+++ b/Assets/Scripts/UI/PanelMenu/PauseMenu.cs
@@ -86,13 +86,18 @@ namespace EVOGAMI.UI.PanelMenu
             controller.OpenOptionsMenu(this);
         }
 
-        /// <summary>
-        ///     Callback for when the exit button is clicked.
-        /// </summary>
-        public void OnExitClicked()
+        // /// <summary>
+        // ///     Callback for when the exit button is clicked.
+        // /// </summary>
+        // public void OnExitClicked()
+        // {
+        //     Debug.Log("OnExitClicked");
+        //     StartCoroutine(Quit());
+        // }
+        
+        public void OnMainMenuClicked()
         {
-            Debug.Log("OnExitClicked");
-            StartCoroutine(Quit());
+            GameManager.Instance.LoadStartMenu();
         }
         
         private IEnumerator Quit()


### PR DESCRIPTION
# Description

Fixes #131 

# Checklist

- [x] This PR does not contain unrelated files that may cause conflicts
- [x] The changes are consistent with the description.
- [x] The changes are consistent with the conventions.
- [x] The changes do not break any existing functionality.
